### PR TITLE
RequestHeadersMiddleware should return an empty Hash by default instead of nil

### DIFF
--- a/lib/request_headers_middleware.rb
+++ b/lib/request_headers_middleware.rb
@@ -11,7 +11,7 @@ module RequestHeadersMiddleware # :nodoc:
   @callbacks = []
 
   def store
-    RequestStore[:headers]
+    RequestStore[:headers] ||= {}
   end
 
   def setup(config)

--- a/spec/request_headers_middleware_spec.rb
+++ b/spec/request_headers_middleware_spec.rb
@@ -13,6 +13,10 @@ describe RequestHeadersMiddleware::Middleware do
                                               'CONTENT_TYPE' => 'text/plain')
     end
 
+    it 'returns an empty Hash by default' do
+      expect(RequestHeadersMiddleware.store).to eq({})
+    end
+
     it 'only saves the X-Request-Id in RequestHeadersMiddleware.store' do
       subject.call(env)
       expect(app['CONTENT_TYPE']).to eq('text/plain')


### PR DESCRIPTION
If used in a different environment then Rails the headers Hash defaults to nil which breaks dependencies. The expectation should be an empty Hash and not nil.
This is fixed here.