### PR TITLE
RequestHeadersMiddleware should return an empty Hash by default instead of nil

### DIFF
--- a/lib/request_headers_middleware.rb
+++ b/lib/request_headers_middleware.rb
@@ -11,7 +11,7 @@ module RequestHeadersMiddleware # :nodoc:
   @callbacks = []
 
   def store
-    RequestStore[:headers]
+    RequestStore[:headers] ||= {}
   end
 
   def setup(config)

--- a/lib/request_headers_middleware.rb
+++ b/lib/request_headers_middleware.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'byebug'
 require 'request_headers_middleware/railtie' if defined?(Rails)
 require 'request_headers_middleware/middleware'
 

--- a/spec/request_headers_middleware_spec.rb
+++ b/spec/request_headers_middleware_spec.rb
@@ -13,6 +13,10 @@ describe RequestHeadersMiddleware::Middleware do
                                               'CONTENT_TYPE' => 'text/plain')
     end
 
+    it 'returns an empty Hash by default' do
+      expect(RequestHeadersMiddleware.store).to eq({})
+    end
+
     it 'only saves the X-Request-Id in RequestHeadersMiddleware.store' do
       subject.call(env)
       expect(app['CONTENT_TYPE']).to eq('text/plain')


### PR DESCRIPTION
This PR fixes a bug found when using RequestHeadersMiddleware.store outside of Rails (like Delayed::Job, messeage_queue). There it defaults to nil instead of an empty Hash which it should default to. Dependent software might fail because of this. This PR introduces the empty Hash.